### PR TITLE
Allow Custom Table names

### DIFF
--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBBucketDataAccessProvider.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBBucketDataAccessProvider.kt
@@ -89,6 +89,11 @@ class DynamoDBBucketDataAccessProvider(
         return response.hasAttributes()
     }
 
+    private val _bucketsTableName: String = _config.getBucketsTableNameOverride()
+    
+    init {
+        BucketsTable.name = _bucketsTableName
+    }
     private object BucketsTable : Table("curity-bucket")
     {
         val subject = StringAttribute("subject")

--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBDeviceDataAccessProvider.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBDeviceDataAccessProvider.kt
@@ -67,6 +67,11 @@ class DynamoDBDeviceDataAccessProvider(
 {
     private val _jsonHandler = _configuration.getJsonHandler()
 
+    private val _deviceTableName: String = _configuration.getDeviceTableNameOverride()
+    init {
+        deviceTableName = _deviceTableName
+    }
+
     object DeviceTable : Table("curity-devices")
     {
         // Each device has two items in the table, with the following primary key structure
@@ -530,6 +535,8 @@ class DynamoDBDeviceDataAccessProvider(
 
     companion object
     {
+        lateinit var deviceTableName: String
+
         private val _logger: Logger = LoggerFactory.getLogger(DynamoDBDeviceDataAccessProvider::class.java)
 
         private const val SK_FOR_ID_ITEM = "sk"

--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBDynamicallyRegisteredClientDataAccessProvider.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBDynamicallyRegisteredClientDataAccessProvider.kt
@@ -52,6 +52,11 @@ class DynamoDBDynamicallyRegisteredClientDataAccessProvider(
 {
     private val _jsonHandler = configuration.getJsonHandler()
 
+    private val _dcrTableName: String = configuration.getDcrTableNameOverride()
+    
+    init {
+        DcrTable.name = _dcrTableName
+    }
     private object DcrTable : Table("curity-dynamic-clients")
     {
         val clientId = StringAttribute("clientId")

--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBSessionDataAccessProvider.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBSessionDataAccessProvider.kt
@@ -32,6 +32,11 @@ class DynamoDBSessionDataAccessProvider(
     private val _configuration: DynamoDBDataAccessProviderConfiguration
 ) : SessionDataAccessProvider
 {
+    private val _sessionTableName: String = _configuration.getSessionTableNameOverride()
+    
+    init {
+        SessionTable.name = _sessionTableName
+    }
     object SessionTable : Table("curity-sessions")
     {
         val id = StringAttribute("id")

--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBUserAccountDataAccessProvider.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/DynamoDBUserAccountDataAccessProvider.kt
@@ -1036,6 +1036,14 @@ class DynamoDBUserAccountDataAccessProvider(
             "meta"
         ))
 
+
+    private val _accountsTableName: String = _configuration.getAccountsTableNameOverride()
+    private val _linksTableName: String = _configuration.getLinksTableNameOverride()
+    
+    init {
+        AccountsTable.name = _accountsTableName
+        LinksTable.name = _linksTableName
+    }
     object AccountsTable : Table("curity-accounts")
     {
         val pk = KeyStringAttribute("pk")

--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/configuration/DynamoDBDataAccessProviderConfiguration.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/configuration/DynamoDBDataAccessProviderConfiguration.kt
@@ -18,6 +18,7 @@ package io.curity.identityserver.plugin.dynamodb.configuration
 import se.curity.identityserver.sdk.config.Configuration
 import se.curity.identityserver.sdk.config.OneOf
 import se.curity.identityserver.sdk.config.annotation.DefaultBoolean
+import se.curity.identityserver.sdk.config.annotation.DefaultString
 import se.curity.identityserver.sdk.config.annotation.DefaultLong
 import se.curity.identityserver.sdk.config.annotation.Description
 import se.curity.identityserver.sdk.config.annotation.RangeConstraint
@@ -111,4 +112,42 @@ interface DynamoDBDataAccessProviderConfiguration : Configuration
     fun getExceptionFactory(): ExceptionFactory
 
     fun getJsonHandler(): Json
+
+    // TableNames
+    @Description("Override Device Table Name")
+    @DefaultString("curity-devices")
+    fun getDeviceTableNameOverride(): String
+
+    @Description("Override Buckets Table Name")
+    @DefaultString("curity-bucket")
+    fun getBucketsTableNameOverride(): String
+
+    @Description("Override Dynamic Clients Table Name")
+    @DefaultString("curity-dynamic-clients")
+    fun getDcrTableNameOverride(): String
+
+    @Description("Override Accounts Table Name")
+    @DefaultString("curity-accounts")
+    fun getAccountsTableNameOverride(): String
+
+    @Description("Override Sessions Table Name")
+    @DefaultString("curity-sessions")
+    fun getSessionTableNameOverride(): String
+
+    @Description("Override Links Table Name")
+    @DefaultString("curity-links")
+    fun getLinksTableNameOverride(): String
+
+    @Description("Override Delegations Table Name")
+    @DefaultString("curity-delegations")
+    fun getDelegationTableNameOverride(): String
+
+    @Description("Override Nonce Table Name")
+    @DefaultString("curity-nonces")
+    fun getNonceTableNameOverride(): String
+
+    @Description("Override Token Table Name")
+    @DefaultString("curity-tokens")
+    fun getTokenTableNameOverride(): String
+
 }

--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/schema.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/schema.kt
@@ -42,7 +42,7 @@ enum class AttributeType(val typeName: String)
 }
 
 // A DynamoDB table
-abstract class Table(val name: String)
+abstract class Table(var name: String)
 {
     override fun toString() = name
 }

--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/token/DynamoDBDelegationDataAccessProvider.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/token/DynamoDBDelegationDataAccessProvider.kt
@@ -68,6 +68,10 @@ class DynamoDBDelegationDataAccessProvider(
      * - The "scopeClaims" property is not stored, since it is deprecated and this DAP doesn't need to support legacy
      * delegation formats.
      */
+    private val _delegationTableName = _configuration.getDelegationTableNameOverride()
+    init {
+        DelegationTable.name = _delegationTableName
+    }
     object DelegationTable : Table("curity-delegations")
     {
         val version = StringAttribute("version")

--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/token/DynamoDBNonceDataAccessProvider.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/token/DynamoDBNonceDataAccessProvider.kt
@@ -34,6 +34,10 @@ class DynamoDBNonceDataAccessProvider(
     private val _configuration: DynamoDBDataAccessProviderConfiguration
 ) : NonceDataAccessProvider
 {
+    private val _nonceTableName = _configuration.getNonceTableNameOverride()
+    init {
+        NonceTable.name = _nonceTableName
+    }
     object NonceTable : Table("curity-nonces")
     {
         val nonce = StringAttribute("nonce")

--- a/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/token/DynamoDBTokenDataAccessProvider.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/dynamodb/token/DynamoDBTokenDataAccessProvider.kt
@@ -41,6 +41,10 @@ class DynamoDBTokenDataAccessProvider(
 {
     private val _jsonHandler = _configuration.getJsonHandler()
 
+    private val _tokenTableName = _configuration.getTokenTableNameOverride()
+    init {
+        TokenTable.name = _tokenTableName
+    }
     object TokenTable : Table("curity-tokens")
     {
         val tokenHash = StringAttribute("tokenHash")


### PR DESCRIPTION
DynamoDB does not has any namespace concept, except account. 
This patch allows to override hard-coded table dynamo table names.